### PR TITLE
CI: Publish OTA release on merged PRs to main and remove artifact upload

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -2,17 +2,16 @@ name: CI
 
 on:
   pull_request:
-    types: [closed]
-    branches: ["main"]
-
+    branches: ["master"]
+  push:
+    branches: ["master"]
   workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
-  release:
-    if: github.event.pull_request.merged == true
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -20,6 +19,14 @@ jobs:
 
       - name: Build skins
         run: ./build_skins.sh
+
+  release:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Create OTA release archive
         run: |

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,37 +1,38 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "master" branch
-  push:
-    branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
+    types: [closed]
+    branches: ["main"]
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+permissions:
+  contents: write
+
 jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
+  release:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
+      - name: Build skins
         run: ./build_skins.sh
 
-      - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v3
+      - name: Create OTA release archive
+        run: |
+          mkdir -p dist
+          cd OTA
+          find . -type f ! -path './.*' ! -path '*/.*' -print0 \
+            | sort -z \
+            | tar --null -czf "../dist/ota-${GITHUB_SHA}.tar.gz" --files-from -
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
         with:
-          name: SamsungGalaxyS7.skin
-          path: OTA/SamsungGalaxyS7.skin
-          retention-days: 5
+          tag_name: ota-${{ github.sha }}
+          name: OTA Release ${{ github.sha }}
+          generate_release_notes: true
+          files: dist/ota-${{ github.sha }}.tar.gz


### PR DESCRIPTION
### Motivation
- Replace per-job artifact uploads with a GitHub Release flow so full OTA content can be published automatically when a PR is merged to `main`.

### Description
- Changed workflow trigger to `pull_request` `types: [closed]` targeting `main` and gated the job with `if: github.event.pull_request.merged == true` so the job runs only for merged PRs.
- Removed the `actions/upload-artifact` step and added a packaging step that archives all non-hidden files under `OTA/` into `dist/ota-${GITHUB_SHA}.tar.gz` using `find` and `tar` (excluding dotfiles and hidden directories).
- Added a release publishing step using `softprops/action-gh-release@v2` which publishes the created tarball as a release asset and uses `tag_name: ota-${{ github.sha }}` and `name: OTA Release ${{ github.sha }}`.
- Set workflow permission `contents: write` and updated checkout action to `actions/checkout@v4`.

### Testing
- Ran `./build_skins.sh` locally; the script completed (exit code 0) but emitted expected warnings about missing theme files and some zip I/O messages in this checkout.
- Verified the updated workflow file at `.github/workflows/blank.yml` and committed the change successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ffc4749cc8331b0c0ea73a972505d)